### PR TITLE
renew the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:20.04 AS builder
 
 LABEL maintainer="Yury Muski <muski.yury@gmail.com>"
 
 ENV NGINX_PATH /etc/nginx
-ENV NGINX_VERSION 1.16.1
+ENV NGINX_VERSION 1.19.6
 
 WORKDIR /opt
 
 RUN apt-get update && \
-    apt-get install -y libpcre3 libpcre3-dev zlib1g-dev zlib1g golang-go build-essential git curl cmake;
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libpcre3 libpcre3-dev zlib1g-dev zlib1g golang-go build-essential git curl cmake;
 
 RUN curl -O https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \
     tar xvzf nginx-$NGINX_VERSION.tar.gz && \
@@ -66,14 +66,14 @@ RUN curl -O https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \
     make && \
     make install;
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY --from=builder /usr/sbin/nginx /usr/sbin/
 COPY --from=builder /etc/nginx/ /etc/nginx/
 
 
-RUN groupadd  nginx \
-  && useradd -m -d  /var/cache/nginx -s /sbin/nologin -g nginx nginx \
+RUN groupadd -g 1000 nginx \
+  && useradd -m -u 1000 -d /var/cache/nginx -s /sbin/nologin -g nginx nginx \
   # forward request and error logs to docker log collector
   && mkdir -p /var/log/nginx \
   && touch /var/log/nginx/access.log /var/log/nginx/error.log \
@@ -81,7 +81,7 @@ RUN groupadd  nginx \
   && ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
-EXPOSE 80
+EXPOSE 80 443
 
 STOPSIGNAL SIGTERM
 


### PR DESCRIPTION
Hi there, thanks for your work! I've tried to renew the image but turned out I can't use it for my site, I hope my changes might e useful for you. They are:

- bump Ubuntu from 18.04 to 20.04
- bump Nginx from 1.16.1 to 1.19.6 (last one with working quiche patch currently)
- set gid and uid for the Nginx group and user explicitly on the creation
- expose port 443 as that's the port that image likely will be used with

I can't get my browsers to recognize the site's http3, however, the curl command you provided in Readme does work with the current master version and doesn't work with a version in that MR, I don't know the reason and I don't know how to test it properly. If you'll decide to merge it, please test it beforehand: maybe I should downgrade Nginx to make it work.